### PR TITLE
Corrected github repo URL in Postgre build instruction

### DIFF
--- a/buildmimic/postgres/README.md
+++ b/buildmimic/postgres/README.md
@@ -14,7 +14,7 @@ First ensure that Postgres is running on your computer. For installation instruc
 Once Postgres is installed, clone the [mimic-iv](https://github.com/MIT-LCP/mimic-iv) repository into a local directory. We only need the contents of this directory, but it's useful to have the repository locally. You can clone the repository using the following command:
 
 ``` bash
-git clone https://github.com/MIT-LCP/mimic-code.git
+git clone https://github.com/MIT-LCP/mimic-iv.git
 ```
 
 Change to the `buildmimic/postgres/` directory. Create the schemas and tables with the following psql command. **This will delete any data present in the schemas.**


### PR DESCRIPTION
I found this error in the build instruction for postgres which points to the old [MIT-LCP/mimic-code](https://github.com/MIT-LCP/mimic-code). Corrected to the current repository.