### PR TITLE
Set lactate and glucose range in bg script

### DIFF
--- a/concepts/measurement/bg.sql
+++ b/concepts/measurement/bg.sql
@@ -19,10 +19,10 @@ select
   , MAX(CASE WHEN itemid = 50805 THEN valuenum ELSE NULL END) AS carboxyhemoglobin
   , MAX(CASE WHEN itemid = 50806 THEN valuenum ELSE NULL END) AS chloride
   , MAX(CASE WHEN itemid = 50808 THEN valuenum ELSE NULL END) AS calcium
-  , MAX(CASE WHEN itemid = 50809 THEN valuenum ELSE NULL END) AS glucose
+  , MAX(CASE WHEN itemid = 50809 and valuenum <= 10000 THEN valuenum ELSE NULL END) AS glucose
   , MAX(CASE WHEN itemid = 50810 and valuenum <= 100 THEN valuenum ELSE NULL END) AS hematocrit
   , MAX(CASE WHEN itemid = 50811 THEN valuenum ELSE NULL END) AS hemoglobin
-  , MAX(CASE WHEN itemid = 50813 THEN valuenum ELSE NULL END) AS lactate
+  , MAX(CASE WHEN itemid = 50813 and valuenum <= 10000 THEN valuenum ELSE NULL END) AS lactate
   , MAX(CASE WHEN itemid = 50814 THEN valuenum ELSE NULL END) AS methemoglobin
   , MAX(CASE WHEN itemid = 50815 THEN valuenum ELSE NULL END) AS o2flow
   -- fix a common unit conversion error for fio2


### PR DESCRIPTION
I got `ERROR:  value out of range: underflow` when running this script on postgres due to one subject_id with glucose and lactate value of 1276103 and the `exp` function doesn't like that. I put the upper bound as 10000 for both here but maybe there's a better threshold since I saw a few other patients with lactate > 50 mmol/L, even some with > 100 mmol/L. There might be unrealistic values in other lab tests other than these 2 too but I haven't checked.