### PR TITLE
Subquery alias for postgres

### DIFF
--- a/concepts/measurement/urine_output.sql
+++ b/concepts/measurement/urine_output.sql
@@ -32,6 +32,6 @@ from
     227488, -- GU Irrigant Volume In
     227489  -- GU Irrigant/Urine Volume Out
     )
-)
+) uo
 group by stay_id, charttime
 order by stay_id, charttime;


### PR DESCRIPTION
Another fix to make postgres happy. Subquery alias is required at all time even when there's no ambiguity