### PR TITLE
Some ideas on sepsis-3 definition

### DIFF
--- a/concepts/sepsis/sepsis3.sql
+++ b/concepts/sepsis/sepsis3.sql
@@ -1,57 +1,40 @@
-WITH s1 as 
+-- Around each suspicion of infection, check the changes of the current SOFA score from the beginning of the window
+, sofa_scores as
 (
-  SELECT 
-    sofa.* 
-    , soi.subject_id
-    , soi.ab_id
-    , soi.antibiotic
-    , soi.antibiotic_time
-    , soi.culture_time
-    , soi.suspected_infection
-    , soi.suspected_infection_time
-    , soi.specimen
-    , soi.positive_culture
-  FROM `lcp-internal.sepsis_test.suspicion_of_infection` as soi
-  INNER JOIN `lcp-internal.sepsis_test.sofa` as sofa
-    ON soi.stay_id = sofa.stay_id 
-    AND sofa.starttime >= DATETIME_SUB(soi.suspected_infection_time, INTERVAL 48 HOUR)
-    AND sofa.endtime <= DATETIME_ADD(soi.suspected_infection_time, INTERVAL 24 HOUR)
-  WHERE sofa.stay_id is not null and soi.stay_id is not null
+select 
+    sus.stay_id, hr, starttime, endtime, t_suspicion, sofa_24hours
+    , first_value(sofa_24hours) over (partition by sofa.stay_id, t_suspicion order by sofa.stay_id, t_suspicion, starttime) as initial_sofa
+    , sofa_24hours - first_value(sofa_24hours) over (partition by sofa.stay_id, t_suspicion order by sofa.stay_id, t_suspicion, starttime) as sofa_difference
+from `physionet-data.mimic_derived.suspicion_of_infection` sus
+left join `physionet-data.mimic_derived.sofa` sofa
+    on sus.stay_id = sofa.stay_id
+-- the following is the largest interval suggested by the sepsis-3 paper, though their sensitivity analysis checked +-3 hours upwards
+where starttime <= datetime_add(t_suspicion, interval 24 hour)
+    and starttime >= datetime_sub(t_suspicion, interval 48 hour) 
+order by sofa.stay_id, t_suspicion, starttime
 )
-, s2 as 
+
+-- find where the SOFA score has increased by 2 within the time sensitivity being investigated
+-- Note the sepsis-3 papers mentions that the baseline of a patient should be zero so an alternative is just to test if the total SOFA score exceeds 2. However that approach would have lower specificity and may be less clinically interesting
+, sofa_times as 
 (
-  SELECT distinct 
-    stay_id, subject_id
-    , suspected_infection
-    , suspected_infection_time
-    , starttime, endtime
-    , respiration
-    , coagulation
-    , liver
-    , cardiovascular
-    , cns
-    , renal
-    , coalesce(respiration, 0)
-      + coalesce(coagulation, 0)
-      + coalesce(liver, 0)
-      + coalesce(cardiovascular, 0)
-      + coalesce(cns, 0)
-      + coalesce(renal, 0) as sofa_score
-    , coalesce(respiration, 0)
-      + coalesce(coagulation, 0)
-      + coalesce(liver, 0)
-      + coalesce(cardiovascular, 0)
-      + coalesce(cns, 0)
-      + coalesce(renal, 0) >= 2 
-      and suspected_infection = 1 as sepsis3
-  FROM s1
+select stay_id, t_suspicion, min(starttime) as t_sofa
+from sofa_scores
+where sofa_difference>=2
+group by stay_id, t_suspicion
 )
-, s3 as 
+
+-- Find the first time when the sepsis-3 requirements are satisfied
+, first_event as
 (
-  SELECT 
-    *, ROW_NUMBER() OVER (PARTITION BY stay_id, suspected_infection_time ORDER BY stay_id, suspected_infection_time, starttime) as rn
-  FROM s2
-  WHERE sepsis3
+select stay_id, min(t_suspicion) as t_suspicion, min(t_sofa) as t_sofa from sofa_times
+    group by stay_id
 )
-SELECT * FROM s3
-WHERE rn = 1
+
+select subject_id, hadm_id, ie.stay_id, intime, outtime
+    , t_suspicion, t_sofa 
+    -- some papers may take the minimum to define sepsis time
+    , least(t_suspicion, t_sofa) as t_sepsis_min
+from `physionet-data.mimic_icu.icustays` ie
+left join first_event fe on ie.stay_id = fe.stay_id
+order by subject_id, intime


### PR DESCRIPTION
An adapted version of the code we have used for early detection of sepsis using the sepsis-3 definition. 

For us, early detection of sepsis was key and since there are virtually no vital signs data outside of ICU, we used the inputevents table. This gave a more precise time of intake, we are able to count the number of doses etc and define a more precise time. For our study, we actually filtered out patients who were prescribed antibiotics prior to ICU admission. This is not in this version but can be easily added

Obviously this approach may not be applicable for all studies on sepsis, but may be of interest to those interested in a precise onset time in the ICU  so perhaps can be an alternative to the available code.

Note the sofa file also assumes the sofa scores to be in a pivoted format so may have to also be adjusted