### PR TITLE
Fix couple of bugs in first day tables

### DIFF
--- a/concepts/firstday/first_day_gcs.sql
+++ b/concepts/firstday/first_day_gcs.sql
@@ -32,7 +32,7 @@ SELECT
     , gcs_motor
     , gcs_verbal
     , gcs_eyes
-    , endotrachflag
+    , gcs_unable
 FROM `physionet-data.mimic_icu.icustays` ie
 LEFT JOIN gcs_final gs
     ON ie.stay_id = gs.stay_id

--- a/concepts/firstday/first_day_height.sql
+++ b/concepts/firstday/first_day_height.sql
@@ -10,7 +10,7 @@ WITH ce AS
       c.stay_id
       , AVG(valuenum) as Height_chart
     FROM `physionet-data.mimic_icu.chartevents` c
-    INNER JOIN`physionet-data.mimic_icu.icustays` ie ON
+    INNER JOIN `physionet-data.mimic_icu.icustays` ie ON
         c.stay_id = ie.stay_id
         AND c.charttime BETWEEN DATETIME_SUB(ie.intime, INTERVAL '1' DAY) AND DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
     WHERE c.valuenum IS NOT NULL

--- a/concepts/firstday/first_day_lab.sql
+++ b/concepts/firstday/first_day_lab.sql
@@ -6,8 +6,8 @@ WITH cbc AS
     , MAX(hematocrit) as hematocrit_max
     , MIN(hemoglobin) as hemoglobin_min
     , MAX(hemoglobin) as hemoglobin_max
-    , MIN(platelets) as platelets_min
-    , MAX(platelets) as platelets_max
+    , MIN(platelet) as platelets_min
+    , MAX(platelet) as platelets_max
     , MIN(wbc) as wbc_min
     , MAX(wbc) as wbc_max
     FROM `physionet-data.mimic_icu.icustays` ie


### PR DESCRIPTION
1. In `first_day_gsc`, column `endotrachflag` in `gcs` should be `gcs_unable`
https://github.com/MIT-LCP/mimic-iv/blob/cfcd708a5e31d37d6491468458b408be292106b6/concepts/measurement/gcs.sql#L136

2. In `first_day_lab`, column `platelets` in `complete_blood_count` should be `platelet`
https://github.com/MIT-LCP/mimic-iv/blob/cfcd708a5e31d37d6491468458b408be292106b6/concepts/measurement/complete_blood_count.sql#L13

3. Change
```
INNER JOIN`physionet-data.mimic_icu.icustays`
```
to
```
INNER JOIN `physionet-data.mimic_icu.icustays`
```
to help with porting to postgres