### PR TITLE
Add stay_id to ventilator_setting

### DIFF
--- a/concepts/measurement/ventilator_setting.sql
+++ b/concepts/measurement/ventilator_setting.sql
@@ -72,6 +72,7 @@ with ce as
 )
 SELECT
       subject_id
+    , MAX(stay_id) AS stay_id
     , charttime
     , MAX(CASE WHEN itemid = 224688 THEN valuenum ELSE NULL END) AS respiratory_rate_set
     , MAX(CASE WHEN itemid = 224690 THEN valuenum ELSE NULL END) AS respiratory_rate_total


### PR DESCRIPTION
This is needed for `ventilator_durations`.

https://github.com/MIT-LCP/mimic-iv/blob/6dc9ec3d8360d0f226d5ba5d542061e839134232/concepts/durations/ventilator_durations.sql#L7-L8
https://github.com/MIT-LCP/mimic-iv/blob/6dc9ec3d8360d0f226d5ba5d542061e839134232/concepts/durations/ventilator_durations.sql#L16