### PR TITLE
fix error in indexing d_icd_procedures in buildmimic/mysql/index.sql

### DIFF
--- a/buildmimic/mysql/index.sql
+++ b/buildmimic/mysql/index.sql
@@ -56,7 +56,7 @@ alter table d_icd_diagnoses
 -- -----------
 
 alter table d_icd_procedures
-  add unique index d_icd_procedures_idx01 (icd_code);
+  add unique index d_icd_procedures_idx01 (icd_code, icd_version);
 
 -- ---------
 -- d_items


### PR DESCRIPTION
To make index in table 'd_icd_procedures', the error would be issued. 
`Error Code: 1062. Duplicate entry '031' for key 'd_icd_procedures_idx01'`

This is because there are same icd_codes with different icd_versions. 
For example, icd_code 031 in version 9 indicates 'Division of intraspinal nerve root', and in version10 indicates 'Upper Arteries, Bypass'.

To fix it, make index with icu_version.
Thanks.